### PR TITLE
Analyzer: Hide UI buttons until audio is available

### DIFF
--- a/ClassifTreinoVoz/AudioComparer/Form1.Designer.cs
+++ b/ClassifTreinoVoz/AudioComparer/Form1.Designer.cs
@@ -120,8 +120,6 @@
             this.toolMain = new System.Windows.Forms.ToolStrip();
             this.btnClient = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.btnVoiceTraining = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.btnZoomIn = new System.Windows.Forms.ToolStripButton();
             this.btnZoomOut = new System.Windows.Forms.ToolStripButton();
             this.btnComputeF0formants = new System.Windows.Forms.ToolStripButton();
@@ -794,8 +792,6 @@
             this.toolMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.btnClient,
             this.toolStripSeparator3,
-            this.btnVoiceTraining,
-            this.toolStripSeparator6,
             this.btnZoomIn,
             this.btnZoomOut,
             this.btnComputeF0formants,
@@ -830,18 +826,6 @@
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
             resources.ApplyResources(this.toolStripSeparator3, "toolStripSeparator3");
-            // 
-            // btnVoiceTraining
-            // 
-            resources.ApplyResources(this.btnVoiceTraining, "btnVoiceTraining");
-            this.btnVoiceTraining.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.btnVoiceTraining.Name = "btnVoiceTraining";
-            this.btnVoiceTraining.Click += new System.EventHandler(this.btnVoiceTraining_Click);
-            // 
-            // toolStripSeparator6
-            // 
-            this.toolStripSeparator6.Name = "toolStripSeparator6";
-            resources.ApplyResources(this.toolStripSeparator6, "toolStripSeparator6");
             // 
             // btnZoomIn
             // 
@@ -1259,8 +1243,6 @@
         private System.Windows.Forms.ToolStripMenuItem audioAnnotationsToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem7;
         private System.Windows.Forms.ToolStripMenuItem regionAnalysisToolStripMenuItem;
-        private System.Windows.Forms.ToolStripButton btnVoiceTraining;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
         private System.Windows.Forms.ToolStripMenuItem formantsToolStripMenuItem;
         private System.Windows.Forms.ToolStripDropDownButton btnPhoneticSymbols;
         private System.Windows.Forms.ToolStripMenuItem s1ToolStripMenuItem;

--- a/ClassifTreinoVoz/AudioComparer/Form1.cs
+++ b/ClassifTreinoVoz/AudioComparer/Form1.cs
@@ -85,8 +85,35 @@ namespace AudioComparer
             }
         }
 
+        private void MakeToolMainItemsVisible()
+        {
+            List<ToolStripItem> restrictedItems = new List<ToolStripItem>()
+            {
+                btnComputeF0formants,
+                btnAnnotate,
+                txtAnnotation,
+                cmbInputDevice
+            };
+
+            //make all menu items visible
+            foreach (ToolStripItem tsi in toolMain.Items)
+            {
+                if (restrictedItems.IndexOf(tsi) < 0) tsi.Visible = true;
+            }
+
+            // update restricted buttons
+            btnComputeF0formants.Visible = isVoiceAnalysisLicensed;
+
+            btnAnnotate.Visible = isVoiceAnalysisLicensed;
+            txtAnnotation.Visible = isVoiceAnalysisLicensed;
+
+            if (cmbInputDevice.Items.Count <= 1) cmbInputDevice.Visible = false;
+            if (cmbInputDevice.Items.Count >= 1) cmbInputDevice.SelectedIndex = 0;
+        }
         private void OpenAudioFile(string filename)
         {
+            MakeToolMainItemsVisible();
+
             //stop playback
             if (replaying && wo != null && wo.PlaybackState == PlaybackState.Playing) btnPlay_Click(this, new EventArgs());
 
@@ -170,10 +197,6 @@ namespace AudioComparer
             filterToolStripMenuItem.Enabled = isVoiceAnalysisLicensed;
 
             btnComputeF0formants.Enabled = isVoiceAnalysisLicensed;
-            btnComputeF0formants.Visible = isVoiceAnalysisLicensed;
-
-            btnAnnotate.Visible = isVoiceAnalysisLicensed;
-            txtAnnotation.Visible = isVoiceAnalysisLicensed;
 
             SampleAudioGL.InfoBarItems = lblFloatingAnnotMenuItems.Text;
 
@@ -307,6 +330,7 @@ namespace AudioComparer
 
                 btnRec.Image = picRec.Image;
 
+                MakeToolMainItemsVisible();
             }
         }
 

--- a/ClassifTreinoVoz/AudioComparer/Form1.resx
+++ b/ClassifTreinoVoz/AudioComparer/Form1.resx
@@ -121,6 +121,37 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="menuMain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="menuMain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1547, 28</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="menuMain.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="menuMain.Text" xml:space="preserve">
+    <value>menuStrip1</value>
+  </data>
+  <data name="&gt;&gt;menuMain.Name" xml:space="preserve">
+    <value>menuMain</value>
+  </data>
+  <data name="&gt;&gt;menuMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuMain.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;menuMain.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="fileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 24</value>
+  </data>
+  <data name="fileToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;File</value>
+  </data>
   <data name="saveToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>268, 26</value>
   </data>
@@ -193,11 +224,17 @@
   <data name="quitToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Quit</value>
   </data>
-  <data name="fileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 24</value>
+  <data name="viewToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 24</value>
   </data>
-  <data name="fileToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;File</value>
+  <data name="viewToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;View</value>
+  </data>
+  <data name="spectreToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>307, 26</value>
+  </data>
+  <data name="spectreToolStripMenuItem.Text" xml:space="preserve">
+    <value>Spectrogram</value>
   </data>
   <data name="monochromaticToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>244, 26</value>
@@ -235,12 +272,6 @@
   <data name="highlightHarmonicsToolStripMenuItem.Text" xml:space="preserve">
     <value>Highlight harmonics</value>
   </data>
-  <data name="spectreToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>307, 26</value>
-  </data>
-  <data name="spectreToolStripMenuItem.Text" xml:space="preserve">
-    <value>Spectrogram</value>
-  </data>
   <data name="toolStripMenuItem2.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 6</value>
   </data>
@@ -249,6 +280,12 @@
   </data>
   <data name="fundamentalFrequencyToolStripMenuItem.Text" xml:space="preserve">
     <value>Fundamental frequency</value>
+  </data>
+  <data name="f0AmplificationToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>307, 26</value>
+  </data>
+  <data name="f0AmplificationToolStripMenuItem.Text" xml:space="preserve">
+    <value>F0 &amp;amplification</value>
   </data>
   <data name="toolStripMenuItemF0Amp1.Size" type="System.Drawing.Size, System.Drawing">
     <value>108, 26</value>
@@ -274,12 +311,6 @@
   <data name="toolStripMenuItemF0Amp4.Text" xml:space="preserve">
     <value>30</value>
   </data>
-  <data name="f0AmplificationToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>307, 26</value>
-  </data>
-  <data name="f0AmplificationToolStripMenuItem.Text" xml:space="preserve">
-    <value>F0 &amp;amplification</value>
-  </data>
   <data name="toolStripMenuItem9.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 6</value>
   </data>
@@ -288,6 +319,12 @@
   </data>
   <data name="intensityToolStripMenuItem.Text" xml:space="preserve">
     <value>Intensity</value>
+  </data>
+  <data name="maximumRelativeIntensitydBrToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>307, 26</value>
+  </data>
+  <data name="maximumRelativeIntensitydBrToolStripMenuItem.Text" xml:space="preserve">
+    <value>Maximum relative intensity (dBr)</value>
   </data>
   <data name="toolStripMenuItemRIntens0.Size" type="System.Drawing.Size, System.Drawing">
     <value>116, 26</value>
@@ -313,12 +350,6 @@
   <data name="toolStripMenuItemRIntens3.Text" xml:space="preserve">
     <value>400</value>
   </data>
-  <data name="maximumRelativeIntensitydBrToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>307, 26</value>
-  </data>
-  <data name="maximumRelativeIntensitydBrToolStripMenuItem.Text" xml:space="preserve">
-    <value>Maximum relative intensity (dBr)</value>
-  </data>
   <data name="toolStripMenuItem15.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 6</value>
   </data>
@@ -327,6 +358,12 @@
   </data>
   <data name="formantsToolStripMenuItem.Text" xml:space="preserve">
     <value>Formants</value>
+  </data>
+  <data name="numberOfFormantsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>307, 26</value>
+  </data>
+  <data name="numberOfFormantsToolStripMenuItem.Text" xml:space="preserve">
+    <value>Number of formants...</value>
   </data>
   <data name="toolStripMenuItem10.Size" type="System.Drawing.Size, System.Drawing">
     <value>100, 26</value>
@@ -358,12 +395,6 @@
   <data name="toolStripMenuItem14.Text" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="numberOfFormantsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>307, 26</value>
-  </data>
-  <data name="numberOfFormantsToolStripMenuItem.Text" xml:space="preserve">
-    <value>Number of formants...</value>
-  </data>
   <data name="toolStripMenuItem17.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 6</value>
   </data>
@@ -382,11 +413,11 @@
   <data name="regionAnalysisToolStripMenuItem.Text" xml:space="preserve">
     <value>Region analysis...</value>
   </data>
-  <data name="viewToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 24</value>
+  <data name="editToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>49, 24</value>
   </data>
-  <data name="viewToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;View</value>
+  <data name="editToolStripMenuItem.Text" xml:space="preserve">
+    <value>Edit</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="baseFrequencyAndFormantsToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
@@ -419,6 +450,12 @@
   <data name="toolStripMenuItem5.Size" type="System.Drawing.Size, System.Drawing">
     <value>330, 6</value>
   </data>
+  <data name="amplifyToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>333, 26</value>
+  </data>
+  <data name="amplifyToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Change volume</value>
+  </data>
   <data name="increaseToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
     <value>Ctrl+Up</value>
   </data>
@@ -437,17 +474,17 @@
   <data name="decreaseToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Decrease</value>
   </data>
-  <data name="amplifyToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>333, 26</value>
+  <data name="filterToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>56, 24</value>
   </data>
-  <data name="amplifyToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Change volume</value>
+  <data name="filterToolStripMenuItem.Text" xml:space="preserve">
+    <value>F&amp;ilter</value>
   </data>
-  <data name="editToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>49, 24</value>
+  <data name="averageToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 26</value>
   </data>
-  <data name="editToolStripMenuItem.Text" xml:space="preserve">
-    <value>Edit</value>
+  <data name="averageToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Average</value>
   </data>
   <data name="menuAvg1ms.Size" type="System.Drawing.Size, System.Drawing">
     <value>134, 26</value>
@@ -473,11 +510,11 @@
   <data name="menuAvg50ms.Text" xml:space="preserve">
     <value>5 ms</value>
   </data>
-  <data name="averageToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="medianToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>214, 26</value>
   </data>
-  <data name="averageToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Average</value>
+  <data name="medianToolStripMenuItem.Text" xml:space="preserve">
+    <value>Median</value>
   </data>
   <data name="msToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>134, 26</value>
@@ -503,23 +540,11 @@
   <data name="msToolStripMenuItem3.Text" xml:space="preserve">
     <value>1.5 ms</value>
   </data>
-  <data name="medianToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>214, 26</value>
-  </data>
-  <data name="medianToolStripMenuItem.Text" xml:space="preserve">
-    <value>Median</value>
-  </data>
   <data name="exportWaveformToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>214, 26</value>
   </data>
   <data name="exportWaveformToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Export waveform...</value>
-  </data>
-  <data name="medianToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 26</value>
-  </data>
-  <data name="medianToolStripMenuItem1.Text" xml:space="preserve">
-    <value>Median</value>
   </data>
   <data name="spectrogramToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>214, 26</value>
@@ -527,11 +552,17 @@
   <data name="spectrogramToolStripMenuItem.Text" xml:space="preserve">
     <value>Spectrogram</value>
   </data>
-  <data name="filterToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 24</value>
+  <data name="medianToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 26</value>
   </data>
-  <data name="filterToolStripMenuItem.Text" xml:space="preserve">
-    <value>F&amp;ilter</value>
+  <data name="medianToolStripMenuItem1.Text" xml:space="preserve">
+    <value>Median</value>
+  </data>
+  <data name="autolearnToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>37, 24</value>
+  </data>
+  <data name="autolearnToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;AI</value>
   </data>
   <data name="loadModelToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>267, 26</value>
@@ -539,7 +570,6 @@
   <data name="loadModelToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Load model...</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="spotKeywordInSelectionToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -612,47 +642,17 @@
   <data name="phoneticSearchToolStripMenuItem.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="autolearnToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 24</value>
-  </data>
-  <data name="autolearnToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;AI</value>
-  </data>
-  <data name="aboutToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 26</value>
-  </data>
-  <data name="aboutToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;About...</value>
-  </data>
   <data name="helpToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>55, 24</value>
   </data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Help</value>
   </data>
-  <data name="menuMain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+  <data name="aboutToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 26</value>
   </data>
-  <data name="menuMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1547, 28</value>
-  </data>
-  <data name="menuMain.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="menuMain.Text" xml:space="preserve">
-    <value>menuStrip1</value>
-  </data>
-  <data name="&gt;&gt;menuMain.Name" xml:space="preserve">
-    <value>menuMain</value>
-  </data>
-  <data name="&gt;&gt;menuMain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;menuMain.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;menuMain.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="aboutToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;About...</value>
   </data>
   <metadata name="toolMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>132, 17</value>
@@ -702,61 +702,7 @@
     <value>Select client</value>
   </data>
   <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>6, 48</value>
-  </data>
-  <data name="btnVoiceTraining.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="btnVoiceTraining.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAATnSURBVFhHxVf9T1tVGObv0SwaM82WLDNjsA27j7A5KEX8
-        WKYRNtre2/K5tqzQ0ZZNRTPMdD/Api7TuTiDZCWaOGPcwA0cH132gaDwgyYkC0uhtBT6+L6n7d297aUt
-        3Q++yQNN7z3v85xznvc9p0XYQKwuTCEyN4jw/T4sjXdjcdQrwJ/5uyg943c2EjkFxNdWEZm+itBQExZv
-        O7F4x43FEQ8Rn8LSaKcAfxbf8TN6h9/lMTw2V2QVEJm9jtCthkRiJvuDZpsH+F0ew2Mjs4FkNv3QFRAn
-        LHKi267ELNMI8gYLoRyci3PqRYaAeGwZod9baUk79JMWAM7FOTl3emgExElmaJjIRz26ibKBZ7k66QPu
-        JxAP+hBWP6ecnDt9JTQCxLIXMvO7XiI9jR8uuuBua4LL0YSvP3cIISvjT9/j3MyhDkUAG07seSppviDy
-        1QkvFvqqsafCgpIKGbuNMna8LuHVciv++c2jFUEcUZUxhQAuF3ZsIYbDn37srbEj3GtET+v7KDHacaDG
-        JmAwyUIEr4SyHcQRGrIrJSoELFPNctmkJ88FntnYgBsvGGRcaX8XoQvV2F7RgH1vJAQweCW+oe1gT6TG
-        MRdzKgJEkylg9pz0Qo8DxUSyu8qOyBcm3Dh9BK8casT+pAjejjZnk1iF1DjmYk4hILbwSHQvdeJ8gSk/
-        vjrnwM7DJMBkh6WuHrhsxID3KLaQiDITCaiU4TnZrBHAYE5u20XRuUBBy8/kvWcdmP7Ria0HJDHbYtr/
-        ZvNx4FIVZs7VoL7WjE0GO66eb9FsAYM5+Vwp4kOE+7j6YTbw4cPG6/a34rkSCyVqw7HjVpRWJpa8lERU
-        vi0hePZNxL804mFPDWZ+diIyliaAOMMP+lC0NP4RJaWDRfUwG/DAh36q9637rXiNXP5OXSMe/2JDvVnC
-        tnIbdpGQnRU2PG9opNWox91vzQiNZPpLcE50o0gcp3kaELSME4F2vGywKi5nk5mOyng4YMPNSxI+7pTx
-        oUfGtc8kjH1nxdwNV8bsBYiTm1LeAmLUbOaHTmHLPis5XFYEMAzVNrxYJuMTfwOC31sxcsWCYH8D5m+1
-        IzKuQ85ICchnCyJjXqwFvaLc9lZrybnctpXL6HBKCI+cxGqwC7FJvyAOU5fUy8dQtiCXCbmDseMPvmVD
-        WZWWnBsO7/vFbgnTg9QNk4T59BTFhHyNylaG+MuPWnMDSisSpZaCgWq8+LANg71W/P1TM1Ymu3THrwel
-        DGPUDPQakSg3cnxnRwt2HNKS7zHyfxnDly3491cXVib8GeNzQTSiJ9SI1mvFy7ScT+50YtMui4a8hErs
-        SK2M4DUrHg8nTCaMrBqbC5pWzH/WO4ww48N7ddRmqdSYfPtBG5wtMqYGJITIRMt65ZUHmEtzGMXjmccx
-        7vnw6QcnsNkg4ZhZxksGG86fIbMF6NAh4mwOzwqePXHF19aeCuDg26v6QsICes40w32CSK9LmKQlnwqQ
-        2QrYbzXEhYTOn1QoAjjEC8krGc9yKtCEe/12qusuzN90I/qs5NmuZBx8YUxdStkobLBospMVvORJiEsp
-        34wTVEpoBHCor+UsYqMO1wPnEjfiXNdydTCx8ITKmBsGT4BypC+7OtYVwMHG/F9+mqnjmX6cUnnnipwC
-        1KH8PKdDJOPnOX0XnR1EjNpr/gH8B580JMIz0t6vAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="btnVoiceTraining.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="btnVoiceTraining.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="btnVoiceTraining.Size" type="System.Drawing.Size, System.Drawing">
-    <value>36, 36</value>
-  </data>
-  <data name="btnVoiceTraining.Text" xml:space="preserve">
-    <value>Voice training</value>
-  </data>
-  <data name="btnVoiceTraining.ToolTipText" xml:space="preserve">
-    <value>Voice training</value>
-  </data>
-  <data name="btnVoiceTraining.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="toolStripSeparator6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>6, 48</value>
-  </data>
-  <data name="toolStripSeparator6.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
+    <value>6, 39</value>
   </data>
   <data name="btnZoomIn.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -811,6 +757,9 @@
   <data name="btnZoomIn.ToolTipText" xml:space="preserve">
     <value>Zoom in</value>
   </data>
+  <data name="btnZoomIn.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="btnZoomOut.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -861,6 +810,9 @@
   </data>
   <data name="btnZoomOut.ToolTipText" xml:space="preserve">
     <value>Zoom out</value>
+  </data>
+  <data name="btnZoomOut.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="btnComputeF0formants.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -932,8 +884,14 @@
   <data name="btnComputeF0formants.ToolTipText" xml:space="preserve">
     <value>Compute f0 and formants in selected region</value>
   </data>
+  <data name="btnComputeF0formants.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="toolStripSeparator7.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 48</value>
+  </data>
+  <data name="toolStripSeparator7.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="btnAnnotate.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -996,6 +954,9 @@
   <data name="btnAnnotate.ToolTipText" xml:space="preserve">
     <value>Annotate selected audio</value>
   </data>
+  <data name="btnAnnotate.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="txtAnnotation.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 14.25pt</value>
   </data>
@@ -1008,53 +969,8 @@
   <data name="txtAnnotation.ToolTipText" xml:space="preserve">
     <value>Phonetic notation</value>
   </data>
-  <data name="s1ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 46</value>
-  </data>
-  <data name="s1ToolStripMenuItem.Text" xml:space="preserve">
-    <value>p b t d k g tʃ dʒ</value>
-  </data>
-  <data name="s2ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 46</value>
-  </data>
-  <data name="s2ToolStripMenuItem.Text" xml:space="preserve">
-    <value>f v θ ð s z ʃ ʒ h m n ŋ</value>
-  </data>
-  <data name="s3ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 46</value>
-  </data>
-  <data name="s3ToolStripMenuItem.Text" xml:space="preserve">
-    <value>l r j w ʔ</value>
-  </data>
-  <data name="s4ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 46</value>
-  </data>
-  <data name="s4ToolStripMenuItem.Text" xml:space="preserve">
-    <value>a ɑ ɪ e ɐ æ ɒ ʌ ʊ o</value>
-  </data>
-  <data name="s8ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 46</value>
-  </data>
-  <data name="s8ToolStripMenuItem.Text" xml:space="preserve">
-    <value>i Y Ʉ Ɯ ʏ Ø ɘ Ɵ ɤ Ə Ɛ ɜ ɞ Ɔ ɶ</value>
-  </data>
-  <data name="s5ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 46</value>
-  </data>
-  <data name="s5ToolStripMenuItem.Text" xml:space="preserve">
-    <value>iː eɪ aɪ ɔɪ</value>
-  </data>
-  <data name="s6ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 46</value>
-  </data>
-  <data name="s6ToolStripMenuItem.Text" xml:space="preserve">
-    <value>ː uː əʊ aʊ ɪə eə ɑː ɔː ʊə ɜː</value>
-  </data>
-  <data name="s7ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 46</value>
-  </data>
-  <data name="s7ToolStripMenuItem.Text" xml:space="preserve">
-    <value>ə i u n̩ l̩ ˈ ~ | ||</value>
+  <data name="txtAnnotation.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="btnPhoneticSymbols.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 18pt</value>
@@ -1086,11 +1002,17 @@
   <data name="btnPhoneticSymbols.ToolTipText" xml:space="preserve">
     <value>Insert phonetic symbol in comment</value>
   </data>
+  <data name="btnPhoneticSymbols.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>6, 48</value>
+    <value>6, 39</value>
+  </data>
+  <data name="toolStripSeparator2.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="cmbInputDevice.Size" type="System.Drawing.Size, System.Drawing">
-    <value>199, 48</value>
+    <value>199, 39</value>
   </data>
   <data name="cmbInputDevice.ToolTipText" xml:space="preserve">
     <value>Select microphone</value>
@@ -1131,7 +1053,7 @@
     <value>Magenta</value>
   </data>
   <data name="btnRec.Size" type="System.Drawing.Size, System.Drawing">
-    <value>34, 45</value>
+    <value>34, 36</value>
   </data>
   <data name="btnRec.ToolTipText" xml:space="preserve">
     <value>Start/stop recording</value>
@@ -1182,31 +1104,46 @@
     <value>Magenta</value>
   </data>
   <data name="btnSaveRecord.Size" type="System.Drawing.Size, System.Drawing">
-    <value>36, 45</value>
+    <value>36, 36</value>
   </data>
   <data name="btnSaveRecord.ToolTipText" xml:space="preserve">
     <value>Save current audio to file</value>
   </data>
+  <data name="btnSaveRecord.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>6, 48</value>
+    <value>6, 39</value>
+  </data>
+  <data name="toolStripSeparator1.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="toolStripLabel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 45</value>
+    <value>70, 36</value>
   </data>
   <data name="toolStripLabel2.Text" xml:space="preserve">
     <value>Speed %:</value>
+  </data>
+  <data name="toolStripLabel2.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="txtReplaySpeed.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="txtReplaySpeed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 48</value>
+    <value>39, 39</value>
   </data>
   <data name="txtReplaySpeed.Text" xml:space="preserve">
     <value>100</value>
   </data>
+  <data name="txtReplaySpeed.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="toolStripSeparator4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>6, 48</value>
+    <value>6, 39</value>
+  </data>
+  <data name="toolStripSeparator4.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="btnPlay.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1254,58 +1191,67 @@
   <data name="btnPlay.ToolTipText" xml:space="preserve">
     <value>Selection play/stop</value>
   </data>
+  <data name="btnPlay.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="lblElapPlayTime.Font" type="System.Drawing.Font, System.Drawing">
     <value>Courier New, 14.25pt</value>
   </data>
   <data name="lblElapPlayTime.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 45</value>
+    <value>54, 36</value>
   </data>
   <data name="lblElapPlayTime.Text" xml:space="preserve">
     <value>0 s</value>
   </data>
+  <data name="lblElapPlayTime.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="toolStripSeparator5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>6, 48</value>
+    <value>6, 39</value>
+  </data>
+  <data name="toolStripSeparator5.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="btnCleanAll.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAhWSURBVFhHjZcJUJXXFcddWjRa2umStGlraRvbUdG01mLF
-        1AxaS0QxarVjg0EhZXFHkAePLYKyCYgsyiIKCg+BB0LYEYsgViBCQDBBsElc0ASSgGFfApz+/988nMwk
-        4Dszv+Hx3e+de+45555z3rRJZLru71NxdXV9SaVSbXZ3d/f1VKtjvLy8Kifw9PTM5XOs7/ZQqVbrvvJ1
-        +YY+vQSbvuLj4xNz5MiR+0f9/HojIiK+TE9Ll1RNqqSlpsuZ+ASJjYmTi6lpoknRSFJiUn9QUNATdze3
-        8aNHjzbAKGe1Wv17nTr9xdjY2MTB3r4zODi4u7KyUkpKSiQwIGCQitXu7gOHHA898XLzqNq/f3/u+vXr
-        Gw8fPnwLnmjA2pCHWj1CI6qqqiQlJWUIxvfgELkeHh4/1amfWlxcXKJ37dr1VenlUuGJvb28PtuyZcvj
-        5cuXu+peSQJHAd26F2SBn4NVIB+YHThwYKWjo2OFk5PTYNK5pF4YMerl6TkAj0RifXLB5vM8PTwHdF/o
-        Wrt2rTsebwW/BX8A/wJ/Ar8GfP53MA+s0f3/G8D17cAYGNnZ2RXs3bt3uOpGjUDvlzDKFM+/XZhEYaFh
-        g/zCtm3bnscjP+CpLE6btgnEgV8BGnQGWIA5wBc4AcoOcBr8ACwE52xtbVMjIyJ7Es8milqlOoVn3y6I
-        5cYA/4Du+Lj4McZ7z549hRstLHg6utwbvACsQCygESYgHmwEPwMnwCHw/Lx585xeXbXqvz5qdUtwUFCv
-        zgOjCIM/1icXbDxafrVCmj+4I9nZ2WNIvl4+c3Z2vuuBL5uamlYsW7YsG956fdGiRQEvGxtXI2ds4LHg
-        1atXf4yb0+Tj7d3FPNJoNCONjU3y4YcfSe3N9+SIj08f9DCUk8tbO3cWhoaEftVyp1W6up7I2NiY9PT0
-        SGNjo+Tm5kpYWFh/yJGQHniqHxv1McuDAoP6o6Oih7KysqSurk46OzuFMjw8LF980akYEBcbN4Ycq9Jt
-        M6WssrW2boLigbutdxUDxsfHZWBgQNrbO6SlpVVqqm/Klctlkp9bKIX5xVJRXim3GhrlwYOH0t3dLaOj
-        o08NaGt7JLGxsUMuzs4fGRoartDtMaUsAyozM7NQuLPXFwmpSUnpu456cPv2+1Jf36BsWJBX9NSAyyWl
-        Ul1VI83Nd+T+/fuKFxISEnib+hgKKyurUuh8A+hVlH4J9oMa4LNixYotK1euLLaxsXkfLn8IN/a7qVQj
-        KDg9KDzC/FCeubl18/bQaG9v72ILCwstErEIOhYDJnEi4M16pvwIBIJasAusA2XgTcDiwyvG9ekzZsxw
-        mDNnziV85u1gTSgAfwE/BnngMGDSaQFvi17yHGDVc9D99QA8xcvg32AJYOWzBmw8NJjX8B+6z38FfI+F
-        6FXAa+cMWKj0kplgN+DpowALDuv43wDv/+/AL0A02ABYiHwADabYgzBAI18HuYC14TWgd1f8J6gHLCw8
-        Md3HKmgAWOkYW+bKK4D1n55gfPmZBswGwYCbs0fwEC5Ab+EmjLsjsATZgC7mCXi6icb0FqAnvgfojQuA
-        5ZflmptzneWaDWvCQ88UhoDuZgi8QBB4CTCZ3AAbEZOMbjUDPO1OwBjPAHQ7Y87GtA0kAJ5+AdBLvgtY
-        42kAs53u54noboaEOcC6T8MYV+aACkzcEobgGOCdtwU5gB6j4XoLG00loPV/BBdBMqBxzPA6QKPWApZX
-        xpmJyefclJ2Qbr8C2EWph17VW3hCFg57IyOjNzAhVaJTFpaVlFzfunXrY1a3a+XlgsIke3bvllJMTOh4
-        smnTpk8zUlIaI8LDtQsWLLgFOLDQIHpR7xDQjc+hirlgILm5YcMGycjIkOQLF8Ta2lpysrOl8to1wcQj
-        MadPS11traAzCsYwqX8PHe/ttwX9n+OYHDx4UBYvXvx44cKFNIA3SH+x2r69xNbGRtmIm6ZqNOLn64s+
-        UC5XSkslMDBQCgoK5Oa770poSIhiZE11tYSGhoq/v79karWCmVG2bN4sjg4OotVqmdz6C4bS0X379snV
-        sjKxWLeO7pVHbW1y7NgxWbJkCeaFD+TC+fPKZxrE9+bPny/x8fHShNaNGVI2WlrKqehosbezE/QH1hO9
-        ZXpMTEzfyZMnRYuTBeG0hTgtXRwNhcVFRWi/DXI+KQkjeapiTEpyMsbyRMUjGenpgilZWTseHKzMEND5
-        HepVtD9DeJcNkpMzO08jxpjvFbdz0zd37FA+32luFnhIkmDAA7RflasrJ2jpaG9XPMTYF+Tny/HjxyU8
-        /KRkZma2Q+cswDBMaQQXaalh+kVtV9WNaiRcpbyT846cOnVKwhDftLQ0SThzRhLPnZPsS5cEnpJIbM7P
-        WZmZcuLECcUIjGPC3wZNjbclOz2nDTp/CGgEDzipEVxkZXsBJ2oqLy8fe4gpZ3BgUJlu7t27h+HjssTF
-        xSPptHI24axgNEPGayQ/v0Dy8vIwlDQr7/b19cknn3yqGJCSdPF/0MneMRdM6QUusrK9aGJi4otsvtXa
-        0jo8PDSsjGX9/f1IxMfK+HW1rEKZiooKSuR65Q2EpUU+/+xzGRkZUcaxwcFBiYqKHk9MTPwYg2w4dLI0
-        G4Ipc+GpB4CpgYGB89KlSzWIZXVtbe2jjo6O4WcZQK/BCx1xcXH1qCM5s2bN8ps5c6Y59OnlAS6w3NJS
-        llY2oNegxGHu3Lm+mH4iUaASzM3NtWvWrLmEqliM4vQfc3OLbEtLy0soOEmzZ8+OwvDpD+P5Q4UNioMo
-        mxmHFebApJtPCF+gmzgZfR/8BLwI+BOM9Z/K2B84vLJBsSP+Wfc/y60RYOPh+/weOyfbNSshPfw1mTbt
-        /2DYhn9mHhd+AAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAhWSURBVFhHjZcJUJXXFcdRWzRa2umStGlLbRvbUdG01mLF
+        1AxaS0QxarVjg0EhZXFHkAePLYCyCYggyCIKynsIPrawKWIRxQpECAgmCDaJewJJwLAvAU7//28eTmYS
+        8J2Z3/D47vfOPfecc885z2gCmaL/+1Q8PDxeUqlUG7y8vAJ91OoEX1/fynF8fHwK+BzrO7xVqhX6r3xd
+        vqHPIMGmr/j7+ycEBATcOxgU1BMTE/NlVmaWZGgzJDMjS04kp0hiQpKczcgUrUYraalpfWFhYU+8PD3H
+        Dh482ACj3NRq9e/16gwXMzMzc2cnp47w8PCuyspKKS0tldCQkAEqVnt59e932f/E19O7as+ePQVr1qxp
+        PHDgwE14ogFrg95q9TCNqKqqEo1GMwjju3GIAm9v75/q1U8u7u7ucdu3b/+q7GKZ8MR+vr6fbdy48fGS
+        JUs89K+kgYOAbt0FcsDPwXJQBCz37t27zMXF5Yqrq+tA2qm0Hhgx4uvj0w+PxGJ9YsHmpj7ePv36L3Su
+        WrXKC483gd+CP4B/gT+BXwM+/zswBSv1//8GcH0LMAOzHR0di3ft2jVUdb1GoPdLGGWB598uTKKoyKgB
+        fmHz5s3P41EQ8FEWjYzWgyTwK0CDTgBrMBMEAldA2QqOgx+AeeCUg4NDRmxMbHfqyVRRq1TxePbtgliu
+        CwkO6UpOSh5lvHfu3Fmyztqap6PL/cALwBYkAhphDpLBOvAzcATsB8+bmpq6vrp8+X/91eqW8LCwHr0H
+        RhCGYKxPLNh4pOLyFWn+4Lbk5eWNIvl6+MzNze2ON75sYWFxZfHixXnw1uvz588PednMrBo5Yw+Pha9Y
+        seJj3Jwmfz+/TuaRVqsdbmxskg8//Ehqb7wnAf7+vdDDUE4sb23bVhIZEflVy+1W6ex8IqOjo9Ld3S2N
+        jY1SUFAgUVFRfREBEd3wVB826mWWh4WG9cUdixvMycmRuro66ejoEMrQ0JB88UWHYkBSYtIocqxKv82k
+        stzBzq4JivvvtN5RDBgbG5P+/n5pa2uXlpZWqam+IZculktRQYmUFF2QKxWVcrOhUe7ffyBdXV0yMjLy
+        1ICHDx9JYmLioLub20cmJiZL9XtMKouBytLSMhLu7AlEQmo1mt5rqAe3br0v9fUNyobFheefGnCxtEyq
+        q2qkufm23Lt3T/FCSkoKb1MvQ2Fra1sGnW8Ag4rSL8EeUAP8ly5dunHZsmUX7O3t34fLH8CNfZ4q1TAK
+        TjcKjzA/lGeenl28PTTaz8/vgrW1tQ6JeB46FgAmcSrgzXqm/AiEglqwHawG5eBNwOLDK8b1KVOnTnWe
+        OXNmLj7zdrAmFIO/gB+DQnAAMOl0gLfFIHkOsOo56/96A57iZfBvsBCw8tkBNh4azGv4D/3nvwK+x0L0
+        KuC1cwMsVAbJNLAD8PTHAAsO6/jfAO//78AvQBxYC1iI/AENpjiBKEAjXwcFgLXhNWBwV/wnqAcsLDwx
+        3ccqaAxY6Rhb5sorgPWfnmB8+ZkGzADhgJuzR/AQ7sBg4SaMuwuwAXmALuYJeLrxxvQWoCe+B+iNM4Dl
+        l+Wam3Od5ZoNa9xDzxSGgO5mCHxBGHgJMJk8ARsRk4xutQQ87TbAGE8FdDtjzsa0GaQAnn4uMEi+C1jj
+        aQCzne7niehuhoQ5wLpPwxhX5oAKjN8ShuAQ4J13APmAHqPhBgsbTSWg9X8EZ0E6oHHM8DpAo1YBllfG
+        mYnJ59yUnZBuvwTYRamHXjVYeEIWDqfZs2e/gQmpEp2ypLy09NqmTZses7pdragQFCbZuWOHlGFiQseT
+        9evXf3pOo2mMiY7WzZ079ybgwEKD6EWDQ0A3Pocq5o6B5MbatWvl3Llzkn7mjNjZ2Ul+Xp5UXr0qmHgk
+        4fhxqautFXRGwRgm9e+h4739tqD/cxyTffv2yYIFCx7PmzePBvAGGS62W7aUOtjbKxtx0wytVoICA9EH
+        KuRSWZmEhoZKcXGx3Hj3XYmMiFCMrKmulsjISAkODpZsnU4wM8rGDRvExdlZdDodk9twwVA6snv3brlc
+        Xi7Wq1fTvfLo4UM5dOiQLFy4EPPCB3Lm9GnlMw3ie3PmzJHk5GRpQuvGDCnrbGwkPi5OnBwdBf2B9cRg
+        mZKQkNB79OhR0eFkYThtCU5LF8dB4YXz59F+G+R0WhpG8gzFGE16OsbyVMUj57KyBFOysnY4PFyZIaDz
+        O9SraH+G8C4bp6dndxxHjDHfK27npm9u3ap8vt3cLPCQpMGA+2i/Kg8PTtDS3tameIixLy4qksOHD0t0
+        9FHJzs5ug87pgGGY1Agu0lKTrLO6zqrr1Ui4Snkn/x2Jj4+XKMQ3MzNTUk6ckNRTpyQvN1fgKYnF5vyc
+        k50tR44cUYzAOCb8bdDUeEvysvIfQucPAY3gASc0gousbC/gRE0VFRWjDzDlDPQPKNPN3bt3MXxclKSk
+        ZCSdTk6mnBSMZsh4rRQVFUthYSGGkmbl3d7eXvnkk08VAzRpZ/8Hnewds8CkXuAiK9uL5ubmgcjmm60t
+        rUNDg0PKWNbX14dEfKyMX5fLryhT0fniUrlWeR1haZHPP/tchoeHlXFsYGBAYmOPjaWmpn6MQTYaOlma
+        TcCkufDUA8DC2NjYbdGiRVrEsrq2tvZRe3v70LMMoNfghfakpKR61JH86dOnB02bNs0K+gzyABdYbmkp
+        Sysb0GtQ4jxr1qxATD+xKFApVlZWupUrV+aiKl5AcfqPlZV1no2NTS4KTtqMGTOOYfgMhvH8ocIGxUGU
+        zYzDCnNgws3HhS/QTZyMvg9+Al4E/AnG+k9l7A8cXtmg2BH/rP+f5XY2YOPh+/weOyfbNSshPfw1MTL6
+        P1vmhnyev4yIAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="btnCleanAll.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
@@ -1315,19 +1261,25 @@
     <value>Magenta</value>
   </data>
   <data name="btnCleanAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>36, 45</value>
+    <value>36, 36</value>
   </data>
   <data name="btnCleanAll.ToolTipText" xml:space="preserve">
     <value>Clear all</value>
+  </data>
+  <data name="btnCleanAll.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="lblNote.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 14.25pt, style=Bold</value>
   </data>
   <data name="lblNote.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 45</value>
+    <value>29, 36</value>
   </data>
   <data name="lblNote.Text" xml:space="preserve">
     <value>  </value>
+  </data>
+  <data name="lblNote.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="toolMain.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 28</value>
@@ -1356,29 +1308,272 @@
   <data name="&gt;&gt;toolMain.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="s1ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>490, 46</value>
+  </data>
+  <data name="s1ToolStripMenuItem.Text" xml:space="preserve">
+    <value>p b t d k g tʃ dʒ</value>
+  </data>
+  <data name="s2ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>490, 46</value>
+  </data>
+  <data name="s2ToolStripMenuItem.Text" xml:space="preserve">
+    <value>f v θ ð s z ʃ ʒ h m n ŋ</value>
+  </data>
+  <data name="s3ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>490, 46</value>
+  </data>
+  <data name="s3ToolStripMenuItem.Text" xml:space="preserve">
+    <value>l r j w ʔ</value>
+  </data>
+  <data name="s4ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>490, 46</value>
+  </data>
+  <data name="s4ToolStripMenuItem.Text" xml:space="preserve">
+    <value>a ɑ ɪ e ɐ æ ɒ ʌ ʊ o</value>
+  </data>
+  <data name="s8ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>490, 46</value>
+  </data>
+  <data name="s8ToolStripMenuItem.Text" xml:space="preserve">
+    <value>i Y Ʉ Ɯ ʏ Ø ɘ Ɵ ɤ Ə Ɛ ɜ ɞ Ɔ ɶ</value>
+  </data>
+  <data name="s5ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>490, 46</value>
+  </data>
+  <data name="s5ToolStripMenuItem.Text" xml:space="preserve">
+    <value>iː eɪ aɪ ɔɪ</value>
+  </data>
+  <data name="s6ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>490, 46</value>
+  </data>
+  <data name="s6ToolStripMenuItem.Text" xml:space="preserve">
+    <value>ː uː əʊ aʊ ɪə eə ɑː ɔː ʊə ɜː</value>
+  </data>
+  <data name="s7ToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>490, 46</value>
+  </data>
+  <data name="s7ToolStripMenuItem.Text" xml:space="preserve">
+    <value>ə i u n̩ l̩ ˈ ~ | ||</value>
+  </data>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>233, 17</value>
   </metadata>
   <data name="gBoxAudio.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
-  <data name="panContainer.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="&gt;&gt;panContainer.Name" xml:space="preserve">
+    <value>panContainer</value>
   </data>
-  <data name="panVideo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+  <data name="&gt;&gt;panContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="panVideo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 4</value>
+  <data name="&gt;&gt;panContainer.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
   </data>
-  <data name="panVideo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="&gt;&gt;panContainer.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtVarPenalty.Name" xml:space="preserve">
+    <value>txtVarPenalty</value>
+  </data>
+  <data name="&gt;&gt;txtVarPenalty.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtVarPenalty.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;txtVarPenalty.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtNFreqs.Name" xml:space="preserve">
+    <value>txtNFreqs</value>
+  </data>
+  <data name="&gt;&gt;txtNFreqs.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtNFreqs.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;txtNFreqs.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtChangePenalty.Name" xml:space="preserve">
+    <value>txtChangePenalty</value>
+  </data>
+  <data name="&gt;&gt;txtChangePenalty.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtChangePenalty.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;txtChangePenalty.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblFloatingAnnotMenuItems.Name" xml:space="preserve">
+    <value>lblFloatingAnnotMenuItems</value>
+  </data>
+  <data name="&gt;&gt;lblFloatingAnnotMenuItems.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFloatingAnnotMenuItems.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;lblFloatingAnnotMenuItems.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtDPenalty.Name" xml:space="preserve">
+    <value>txtDPenalty</value>
+  </data>
+  <data name="&gt;&gt;txtDPenalty.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtDPenalty.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;txtDPenalty.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblSpecInfoCompare.Name" xml:space="preserve">
+    <value>lblSpecInfoCompare</value>
+  </data>
+  <data name="&gt;&gt;lblSpecInfoCompare.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSpecInfoCompare.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;lblSpecInfoCompare.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblSpecInfo.Name" xml:space="preserve">
+    <value>lblSpecInfo</value>
+  </data>
+  <data name="&gt;&gt;lblSpecInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSpecInfo.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;lblSpecInfo.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;picControlBarCompare.Name" xml:space="preserve">
+    <value>picControlBarCompare</value>
+  </data>
+  <data name="&gt;&gt;picControlBarCompare.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;picControlBarCompare.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;picControlBarCompare.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;GLPicSpec2.Name" xml:space="preserve">
+    <value>GLPicSpec2</value>
+  </data>
+  <data name="&gt;&gt;GLPicSpec2.Type" xml:space="preserve">
+    <value>OpenTK.GLControl, OpenTK.GLControl, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4</value>
+  </data>
+  <data name="&gt;&gt;GLPicSpec2.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;GLPicSpec2.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;GLPicIntens2.Name" xml:space="preserve">
+    <value>GLPicIntens2</value>
+  </data>
+  <data name="&gt;&gt;GLPicIntens2.Type" xml:space="preserve">
+    <value>OpenTK.GLControl, OpenTK.GLControl, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4</value>
+  </data>
+  <data name="&gt;&gt;GLPicIntens2.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;GLPicIntens2.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;picStop.Name" xml:space="preserve">
+    <value>picStop</value>
+  </data>
+  <data name="&gt;&gt;picStop.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;picStop.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;picStop.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;glPicSpectre.Name" xml:space="preserve">
+    <value>glPicSpectre</value>
+  </data>
+  <data name="&gt;&gt;glPicSpectre.Type" xml:space="preserve">
+    <value>OpenTK.GLControl, OpenTK.GLControl, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4</value>
+  </data>
+  <data name="&gt;&gt;glPicSpectre.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;glPicSpectre.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;picControlBar.Name" xml:space="preserve">
+    <value>picControlBar</value>
+  </data>
+  <data name="&gt;&gt;picControlBar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;picControlBar.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;picControlBar.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;GLPicIntens.Name" xml:space="preserve">
+    <value>GLPicIntens</value>
+  </data>
+  <data name="&gt;&gt;GLPicIntens.Type" xml:space="preserve">
+    <value>OpenTK.GLControl, OpenTK.GLControl, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4</value>
+  </data>
+  <data name="&gt;&gt;GLPicIntens.Parent" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;GLPicIntens.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="gBoxAudio.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 78</value>
+  </data>
+  <data name="gBoxAudio.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
   </data>
-  <data name="panVideo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>629, 320</value>
+  <data name="gBoxAudio.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
-  <data name="panVideo.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
+  <data name="gBoxAudio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1515, 516</value>
+  </data>
+  <data name="gBoxAudio.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="gBoxAudio.Text" xml:space="preserve">
+    <value>Audio</value>
+  </data>
+  <data name="&gt;&gt;gBoxAudio.Name" xml:space="preserve">
+    <value>gBoxAudio</value>
+  </data>
+  <data name="&gt;&gt;gBoxAudio.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gBoxAudio.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;gBoxAudio.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="panContainer.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
   <data name="&gt;&gt;panVideo.Name" xml:space="preserve">
     <value>panVideo</value>
@@ -1417,6 +1612,33 @@
     <value>gBoxAudio</value>
   </data>
   <data name="&gt;&gt;panContainer.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panVideo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="panVideo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 4</value>
+  </data>
+  <data name="panVideo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="panVideo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>629, 320</value>
+  </data>
+  <data name="panVideo.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;panVideo.Name" xml:space="preserve">
+    <value>panVideo</value>
+  </data>
+  <data name="&gt;&gt;panVideo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panVideo.Parent" xml:space="preserve">
+    <value>panContainer</value>
+  </data>
+  <data name="&gt;&gt;panVideo.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="txtVarPenalty.Location" type="System.Drawing.Point, System.Drawing">
@@ -1858,36 +2080,6 @@ Show/hide in s&amp;pectrogram
   </data>
   <data name="&gt;&gt;GLPicIntens.ZOrder" xml:space="preserve">
     <value>14</value>
-  </data>
-  <data name="gBoxAudio.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 78</value>
-  </data>
-  <data name="gBoxAudio.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="gBoxAudio.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="gBoxAudio.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1515, 516</value>
-  </data>
-  <data name="gBoxAudio.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="gBoxAudio.Text" xml:space="preserve">
-    <value>Audio</value>
-  </data>
-  <data name="&gt;&gt;gBoxAudio.Name" xml:space="preserve">
-    <value>gBoxAudio</value>
-  </data>
-  <data name="&gt;&gt;gBoxAudio.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gBoxAudio.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;gBoxAudio.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="picRec.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -8715,18 +8907,6 @@ Show/hide in s&amp;pectrogram
     <value>toolStripSeparator3</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnVoiceTraining.Name" xml:space="preserve">
-    <value>btnVoiceTraining</value>
-  </data>
-  <data name="&gt;&gt;btnVoiceTraining.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator6.Name" xml:space="preserve">
-    <value>toolStripSeparator6</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator6.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;btnZoomIn.Name" xml:space="preserve">


### PR DESCRIPTION
This PR hides unused buttons in the UI until they are actually useful. The hidden buttons are ones that only do something when audio data is available.